### PR TITLE
nest site under /2025 and redirect root to graphql.org/day/

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  basePath: "/2025",
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -4,6 +4,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "export",
   basePath: "/2025",
+  assetPrefix: "/",
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "packageManager": "bun@1.2.20",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build --turbopack && mv out _out && mkdir -p out/2025 && mv _out/* out/2025/ && rmdir _out",
     "start": "next start",
     "serve": "bunx serve out",
     "typecheck": "tsc --noEmit",

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "packageManager": "bun@1.2.20",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack && mv out _out && mkdir -p out/2025 && mv _out/* out/2025/ && rmdir _out",
+    "build": "next build --turbopack",
     "start": "next start",
     "serve": "bunx serve out",
     "typecheck": "tsc --noEmit",

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -15,13 +15,14 @@ export const metadata: Metadata = {
   },
   description:
     "Join GraphQL Day at CNIT La Defense, Paris on December 11, 2025. Learn from industry experts, participate in hands-on workshops, and connect with the GraphQL community.",
-  metadataBase: new URL("https://graphql.day"),
+  metadataBase: new URL("https://graphql.day/2025"),
   keywords: ["GraphQL", "Conference", "FOST", "11 December 2025", "Paris"],
   applicationName: "GraphQL Day",
   title: {
     absolute: "",
     template: "%s | GraphQL Day",
   },
+  icons: { icon: "/2025/favicon.svg" },
 };
 
 export default function RootLayout({
@@ -32,7 +33,6 @@ export default function RootLayout({
   return (
     <html lang="en" className="scroll-smooth antialiased">
       <head>
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <style>{`html { scroll-padding-top: 5rem }`}</style>
         <FontStyleTag />
       </head>

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,9 +1,13 @@
 {
-  "buildCommand": "next build --turbopack && mv out _out && mkdir -p out/2025 && mv _out/* out/2025/ && rmdir _out",
-  "outputDirectory": "out",
+  "rewrites": [
+    {
+      "source": "/2025/:path*",
+      "destination": "/:path*"
+    }
+  ],
   "redirects": [
     {
-      "source": "/:path((?!2025(?:/|$)).*)",
+      "source": "/:path((?!(?:2025|_next)(?:/|$)).*)",
       "destination": "https://graphql.org/day/:path",
       "permanent": true
     }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,6 @@
 {
+  "buildCommand": "next build --turbopack && mv out _out && mkdir -p out/2025 && mv _out/* out/2025/ && rmdir _out",
+  "outputDirectory": "out",
   "redirects": [
     {
       "source": "/:path((?!2025(?:/|$)).*)",

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,7 +3,7 @@
     {
       "source": "/:path((?!2025/).*)",
       "destination": "https://graphql.org/day/",
-      "permanent": false
+      "permanent": true
     }
   ]
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,8 +1,8 @@
 {
   "redirects": [
     {
-      "source": "/:path((?!2025/).*)",
-      "destination": "https://graphql.org/day/",
+      "source": "/:path((?!2025(?:/|$)).*)",
+      "destination": "https://graphql.org/day/:path",
       "permanent": true
     }
   ]

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/:path((?!2025/).*)",
+      "destination": "https://graphql.org/day/",
+      "permanent": false
+    }
+  ]
+}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,10 +1,4 @@
 {
-  "rewrites": [
-    {
-      "source": "/2025/:path*",
-      "destination": "/:path*"
-    }
-  ],
   "redirects": [
     {
       "source": "/:path((?!2025(?:/|$)).*)",

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,10 @@
 {
+  "rewrites": [
+    {
+      "source": "/2025/:path*",
+      "destination": "/:path*"
+    }
+  ],
   "redirects": [
     {
       "source": "/:path((?!2025(?:/|$)).*)",


### PR DESCRIPTION
- Add basePath: /2025 to next.config.ts
- Move favicon to metadata API with /2025 prefix
- Update metadataBase to include /2025 for OG images
- Add vercel.json with catch-all 301 redirect to graphql.org/day/